### PR TITLE
Adding check for nil certname

### DIFF
--- a/puppetdb-rundeck.rb
+++ b/puppetdb-rundeck.rb
@@ -54,10 +54,12 @@ get '/' do
 	host     = d['certname']
 	name     = d['name'] if d['name'] != "hostname"
         value    = d['value'] if d['name'] != "hostname"
-        if ( name == 'serialnumber' )
+	unless rundeck_resources[host].nil?
+		if ( name == 'serialnumber' )
         	rundeck_resources[host][name] = 'Serial Number ' + value
         else
-		rundeck_resources[host][name] = value
+			rundeck_resources[host][name] = value
+		end
 	end
 	}
 


### PR DESCRIPTION
Our puppetdb instance was returning a few nil certnames, causing this app to throw an error and not return any data. Adding this simple check was enough to stop the error and still return all useful data.
